### PR TITLE
Activity register

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ curl -X PATCH 'http://<host_url>/courses/{id}' \
   "title": "Updated title",
   "description": "Updated description",
   "totalPlaces": 200,
+  "userId": <user_id>,
   ...
 }'
 ```
@@ -76,7 +77,7 @@ curl -X DELETE 'https://<host_url>/courses/{id}'
     curl -X POST 'https://<host_url>/courses/{course_id}/enrollments' \
     -H 'Content-Type: application/json' \
     -d '{
-    "userId": <userId>,
+    "userId": <user_id>,
     "role": <role>,
     }'
 ```
@@ -120,6 +121,7 @@ curl -X DELETE 'https://<host_url>/courses/{course_id}/enrollments/{user_id}'
 
 `<start_date>`, `<end_date>`, and `<registration_date>` are strings of the dates in ISO 8601 format: `YYYY-mm-ddThh:mm:ssZ`. \
 `<teacher_id>` and `<user_id>` must match with the `uuid` used in users service. \
+`<user_id>` is required when requesting a `PATCH` for a course.
 `<role>` must be `"STUDENT"` or `"ASSISTANT"`. \
 `<filters>` are _query params_ which can include an enrollment `userId` and/or `role`.
 

--- a/prisma/migrations/20250523001942_activity_register/migration.sql
+++ b/prisma/migrations/20250523001942_activity_register/migration.sql
@@ -1,0 +1,16 @@
+-- CreateEnum
+CREATE TYPE "Activity" AS ENUM ('EDIT_COURSE', 'ADD_MODULE', 'DELETE_MODULE', 'ADD_EXAM', 'EDIT_EXAM', 'DELETE_EXAM', 'GRADE_EXAM', 'ADD_TASK', 'EDIT_TASK', 'DELETE_TASK', 'GRADE_TASK');
+
+-- CreateTable
+CREATE TABLE "ActivityRegister" (
+    "id" TEXT NOT NULL,
+    "course_id" INTEGER NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "activity" "Activity" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ActivityRegister_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "ActivityRegister" ADD CONSTRAINT "ActivityRegister_course_id_user_id_fkey" FOREIGN KEY ("course_id", "user_id") REFERENCES "Enrollment"("course_id", "user_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,4 +40,30 @@ model Enrollment {
 
   course   Course @relation(fields: [courseId], references: [id], onDelete: Cascade)
   @@id([courseId, userId])
+
+  activityRegister ActivityRegister[]
+}
+
+enum Activity {
+  EDIT_COURSE
+  ADD_MODULE
+  DELETE_MODULE
+  ADD_EXAM
+  EDIT_EXAM
+  DELETE_EXAM
+  GRADE_EXAM
+  ADD_TASK
+  EDIT_TASK
+  DELETE_TASK
+  GRADE_TASK
+}
+
+model ActivityRegister {
+  id         String     @id @default(uuid())
+  courseId   Int        @map("course_id")
+  userId     String     @map("user_id")
+  activity   Activity
+  createdAt  DateTime   @default(now())
+
+  enrollment Enrollment @relation(fields: [courseId, userId], references: [courseId, userId])
 }

--- a/src/controllers/course.controller.ts
+++ b/src/controllers/course.controller.ts
@@ -89,9 +89,6 @@ export class CourseController {
   async updateCourse(@Param('id') id: number, @Body() updateDTO: CourseUpdateDto) {
     logger.info(`Updating course with ID ${id}`);
     const updateCourse = await this.service.updateCourse(id, updateDTO);
-    if (!updateCourse) {
-      throw new NotFoundException(`The course with ID ${id} was not found.`);
-    }
     return updateCourse;
   }
 
@@ -170,5 +167,14 @@ export class CourseController {
   async deleteEnrollment(@Param('courseId') courseId: number, @Param('userId') userId: string) {
     logger.info(`Deleting enrollment for user ${userId} in course ${courseId}`);
     return this.service.deleteEnrollment(courseId, userId);
+  }
+
+  @Get(':courseId/activities')
+  async getCourseActivity(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Query('userId') userId: string,
+  ) {
+    logger.info(`Getting course ${courseId} activity for user ${userId}`);
+    return this.service.getActivities(courseId, userId);
   }
 }

--- a/src/dtos/course.update.dto.ts
+++ b/src/dtos/course.update.dto.ts
@@ -1,4 +1,9 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CourseRequestDto } from './course.request.dto';
+import { IsUUID } from 'class-validator';
 
-export class CourseUpdateDto extends PartialType(CourseRequestDto) {}
+export class CourseUpdateDto extends PartialType(CourseRequestDto) {
+  /** Id of the user who generate the PATCH */
+  @IsUUID()
+  userId: string;
+}

--- a/src/exceptions/exception.forbidden.user.ts
+++ b/src/exceptions/exception.forbidden.user.ts
@@ -1,0 +1,7 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class ForbiddenUserException extends HttpException {
+  constructor(message: string = 'Forbidden') {
+    super(message, HttpStatus.FORBIDDEN);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   );
   app.useGlobalFilters(new BaseExceptionFilter());
   app.useGlobalInterceptors(new ResponseInterceptor());
-  await app.listen(process.env.PORT ?? 3000);
+  await app.listen(process.env.PORT ?? 3002);
 }
 
 void bootstrap();

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -1,6 +1,6 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from 'src/prisma.service';
-import { Prisma, Course, Enrollment } from '@prisma/client';
+import { Prisma, Course, Enrollment, ActivityRegister } from '@prisma/client';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { logger } from 'src/logger';
 import { CourseUpdateEnrollmentDto } from 'src/dtos/course.update.enrollment';
@@ -8,6 +8,7 @@ import { EnrollmentFilterDto } from 'src/dtos/enrollment.filter';
 
 const PRISMA_NOT_FOUND_CODE = 'P2025';
 
+export type CourseWithEnrollments = Course & { enrollments: Enrollment[] };
 export type EnrollmentWithCourse = Enrollment & { course: Course };
 
 @Injectable()
@@ -38,8 +39,14 @@ export class CourseRepository {
   /**
    * Finds a course by its ID.
    */
-  findById(id: number): Promise<Course | null> {
-    return this.prisma.course.findUnique({ where: { id } });
+  findById(
+    id: number,
+    withEnrollments: boolean = false,
+  ): Promise<Course | CourseWithEnrollments | null> {
+    return this.prisma.course.findUnique({
+      where: { id },
+      include: { enrollments: withEnrollments },
+    });
   }
 
   /**
@@ -86,6 +93,12 @@ export class CourseRepository {
     }
   }
 
+  findEnrollment(courseId: number, userId: string): Promise<Enrollment | null> {
+    return this.prisma.enrollment.findUnique({
+      where: { courseId_userId: { courseId, userId } },
+    });
+  }
+
   /**
    * Retrieves a list of enrollments for a specific course.
    *
@@ -93,7 +106,7 @@ export class CourseRepository {
    * @returns A promise that resolves to an array of `Enrollment` objects associated with the course,
    *          or `null` if no enrollments are found.
    */
-  async findCourseEnrollments(id: number): Promise<Enrollment[] | null> {
+  findCourseEnrollments(id: number): Promise<Enrollment[] | null> {
     return this.prisma.enrollment.findMany({
       where: { courseId: id },
     });
@@ -165,5 +178,11 @@ export class CourseRepository {
       }
       throw error;
     }
+  }
+
+  createActivityRegister(
+    data: Prisma.ActivityRegisterUncheckedCreateInput,
+  ): Promise<ActivityRegister> {
+    return this.prisma.activityRegister.create({ data });
   }
 }

--- a/src/repositories/course.repository.ts
+++ b/src/repositories/course.repository.ts
@@ -185,4 +185,8 @@ export class CourseRepository {
   ): Promise<ActivityRegister> {
     return this.prisma.activityRegister.create({ data });
   }
+
+  findActivityRegisterByCourse(courseId: number): Promise<ActivityRegister[]> {
+    return this.prisma.activityRegister.findMany({ where: { courseId } });
+  }
 }

--- a/src/services/course.service.ts
+++ b/src/services/course.service.ts
@@ -297,7 +297,7 @@ export class CourseService {
     }
     if (course.teacherId != userId) {
       throw new ForbiddenUserException(
-        `User ${userId} is not allowed to get the activity register of the course ${courseId}. Only the head teacher is allowed`,
+        `User ${userId} is not allowed to get the activity register of the course ${courseId}. Only the head teacher is allowed.`,
       );
     }
 

--- a/src/services/course.service.ts
+++ b/src/services/course.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { CourseRequestDto } from '../dtos/course.request.dto';
 import { CourseResponseDto } from '../dtos/course.response.dto';
 import { CourseRepository, EnrollmentWithCourse } from '../repositories/course.repository';
-import { Activity, Course, Enrollment, Prisma, Role } from '@prisma/client';
+import { Activity, ActivityRegister, Course, Enrollment, Prisma, Role } from '@prisma/client';
 import { CourseUpdateDto } from 'src/dtos/course.update.dto';
 import { CourseCreateEnrollmentDto } from 'src/dtos/course.create.enrollment';
 import { CourseUpdateEnrollmentDto } from 'src/dtos/course.update.enrollment';
@@ -148,7 +148,7 @@ export class CourseService {
    * @returns The newly created course response DTO, or null if non course with the id exist.
    * @throws {NotFoundException} If the course trying to update is not found.
    */
-  async updateCourse(id: number, updateDTO: CourseUpdateDto): Promise<CourseResponseDto | null> {
+  async updateCourse(id: number, updateDTO: CourseUpdateDto): Promise<CourseResponseDto> {
     const course = await this.repository.findById(id);
     if (!course) {
       throw new NotFoundException(`The course with ID ${id} was not found.`);
@@ -288,5 +288,19 @@ export class CourseService {
     }
 
     return await this.repository.deleteEnrollment(courseId, userId);
+  }
+
+  async getActivities(courseId: number, userId: string): Promise<ActivityRegister[]> {
+    const course = await this.repository.findById(courseId);
+    if (!course) {
+      throw new NotFoundException(`Course with ID ${courseId} not found.`);
+    }
+    if (course.teacherId != userId) {
+      throw new ForbiddenUserException(
+        `User ${userId} is not allowed to get the activity register of the course ${courseId}. Only the head teacher is allowed`,
+      );
+    }
+
+    return this.repository.findActivityRegisterByCourse(courseId);
   }
 }

--- a/test/controller/course.controller.test.ts
+++ b/test/controller/course.controller.test.ts
@@ -114,35 +114,37 @@ describe('CourseController', () => {
 
   test('Should update an existing course', async () => {
     const id = 1;
+    const userId = '123e4567-e89b-12d3-a456-426614174000';
 
-    const courseUpdateDTO = {
+    const courseUpdateData = {
       title: 'Updated Title',
       description: 'Updated Description',
     };
 
     const expected = {
       id,
-      ...courseUpdateDTO,
+      ...courseUpdateData,
       startDate: startDate.toISOString(),
       endDate: endDate.toISOString(),
       registrationDeadline: registrationDeadline.toISOString(),
       totalPlaces: 100,
-      teacherId: '123e4567-e89b-12d3-a456-426614174000',
+      teacherId: userId,
       createdAt: new Date(),
     };
 
     (mockService.updateCourse as jest.Mock).mockResolvedValue(expected);
 
-    const result = await controller.updateCourse(id, courseUpdateDTO);
+    const result = await controller.updateCourse(id, { ...courseUpdateData, userId });
 
     expect(result).toEqual(expected);
-    expect(mockService.updateCourse).toHaveBeenCalledWith(id, courseUpdateDTO);
+    expect(mockService.updateCourse).toHaveBeenCalledWith(id, { ...courseUpdateData, userId });
   });
 
   test('Should throw a NotFoundError when updating a non-existing course', async () => {
     const courseUpdateDTO = {
       title: 'Updated Title',
       description: 'Updated Description',
+      userId: '123e4567-e89b-12d3-a456-426614174000',
     };
 
     (mockService.updateCourse as jest.Mock).mockResolvedValue(undefined);

--- a/test/controller/course.controller.test.ts
+++ b/test/controller/course.controller.test.ts
@@ -2,7 +2,7 @@ import { NotFoundException } from '@nestjs/common';
 import { CourseController } from '../../src/controllers/course.controller';
 import { CourseService } from '../../src/services/course.service';
 import { getDatesAfterToday } from 'test/utils';
-import { Enrollment, Role } from '@prisma/client';
+import { Activity, Enrollment, Role } from '@prisma/client';
 import { EnrollmentFilterDto } from 'src/dtos/enrollment.filter';
 
 describe('CourseController', () => {
@@ -22,6 +22,7 @@ describe('CourseController', () => {
       getEnrollments: jest.fn(),
       updateEnrollment: jest.fn(),
       deleteEnrollment: jest.fn(),
+      getActivities: jest.fn(),
     } as any;
     controller = new CourseController(mockService);
   });
@@ -138,18 +139,6 @@ describe('CourseController', () => {
 
     expect(result).toEqual(expected);
     expect(mockService.updateCourse).toHaveBeenCalledWith(id, { ...courseUpdateData, userId });
-  });
-
-  test('Should throw a NotFoundError when updating a non-existing course', async () => {
-    const courseUpdateDTO = {
-      title: 'Updated Title',
-      description: 'Updated Description',
-      userId: '123e4567-e89b-12d3-a456-426614174000',
-    };
-
-    (mockService.updateCourse as jest.Mock).mockResolvedValue(undefined);
-
-    await expect(controller.updateCourse(999, courseUpdateDTO)).rejects.toThrow(NotFoundException);
   });
 
   test('Should retrieve an enrollment to a course', async () => {
@@ -282,5 +271,36 @@ describe('CourseController', () => {
 
     expect(result).toEqual(expected);
     expect(mockService.deleteEnrollment).toHaveBeenCalledWith(courseId, userId);
+  });
+
+  test('Should get the activity register of an specified course', async () => {
+    const courseId = 1;
+    const userId = '123e4567-e89b-12d3-a456-426614174000';
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const expected = [
+      {
+        courseId,
+        userId: '123e4567-e89b-12d3-a456-426614174001',
+        id: '123e4567-e89b-12d3-a456-426614175555',
+        activity: Activity.EDIT_COURSE,
+        createdAt: yesterday,
+      },
+      {
+        courseId,
+        userId: '123e4567-e89b-12d3-a456-426614174001',
+        id: '123e4567-e89b-12d3-a456-426614175556',
+        activity: Activity.ADD_EXAM,
+        createdAt: yesterday,
+      },
+    ];
+
+    (mockService.getActivities as jest.Mock).mockResolvedValue(expected);
+
+    const result = await controller.getCourseActivity(courseId, userId);
+
+    expect(mockService.getActivities).toHaveBeenCalledWith(courseId, userId);
+    expect(result).toBe(expected);
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -21,6 +21,7 @@ export function getDatesAfterToday(): {
 export async function cleanDataBase(prisma: PrismaClient) {
   await prisma.$transaction([
     // IMPORTANT: respect order by FK relation in case it dont't use 'CASCADE'
+    prisma.activityRegister.deleteMany(),
     prisma.course.deleteMany(),
   ]);
 }


### PR DESCRIPTION
## Activity Register Feature & Course Update Audit

This branch introduces an **Activity Register** system to log course-related activities performed by users (course assistants).

- New endpoint: `GET /courses/:courseId/activities?userId=...` lets head teachers retrieve the activity log for a course.
- Updated course update (`PATCH /courses/:id`):
  - Requires a `userId` (the updater's UUID).
  - Only head teachers and assistants can update. Others receive a 403 error.
  - Logs activities by assistants in the `ActivityRegister` table.

- Added `ForbiddenUserException` for unauthorized update attempts.
- Enforced `userId` validation in update DTOs.

Provides traceability for course modifications, ensuring only authorized users can update courses, and all changes by assistants are logged for transparency.
