### PR TITLE
fix: improve assessment dates filters.

### DIFF
--- a/src/controllers/assessment.controller.ts
+++ b/src/controllers/assessment.controller.ts
@@ -9,7 +9,7 @@ export class AssessmentController {
 
   @Get()
   async getAssessments(@Query() filter: AssessmentFilterDto) {
-    logger.debug(
+    logger.log(
       `Getting the assessments that match with ${filter ? `the filters: ${JSON.stringify(filter)}` : 'non filters'}`,
     );
     return await this.service.getAssessments(filter);

--- a/src/dtos/assessment/assessment.filter.dto.ts
+++ b/src/dtos/assessment/assessment.filter.dto.ts
@@ -1,4 +1,23 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { OmitType, PartialType } from '@nestjs/mapped-types';
 import { AssessmentCreateDto } from './assessment.create.dto';
+import { IsDateString, IsOptional } from 'class-validator';
 
-export class AssessmentFilterDto extends PartialType(AssessmentCreateDto) {}
+export class AssessmentFilterDto extends PartialType(
+  OmitType(AssessmentCreateDto, ['startTime', 'deadline'] as const),
+) {
+  @IsOptional()
+  @IsDateString()
+  startTimeBegin?: string;
+
+  @IsOptional()
+  @IsDateString()
+  startTimeEnd?: string;
+
+  @IsOptional()
+  @IsDateString()
+  deadlineBegin?: string;
+
+  @IsOptional()
+  @IsDateString()
+  deadlineEnd?: string;
+}

--- a/src/repositories/assessment.repository.ts
+++ b/src/repositories/assessment.repository.ts
@@ -26,11 +26,31 @@ export class AssessmentRepository {
   async findAssessments(filter: AssessmentFilterDto): Promise<Assessment[]> {
     // Elimina las propiedades undefined o null del filtro
     const query: Record<string, any> = {};
-    Object.entries(filter).forEach(([key, value]) => {
+
+    // Extraer los valores especiales
+    const { startTimeBegin, startTimeEnd, deadlineBegin, deadlineEnd, ...rest } = filter;
+
+    // Clean and add basic fields
+    Object.entries(rest).forEach(([key, value]) => {
       if (value !== undefined && value !== null) {
         query[key] = value;
       }
     });
+
+    // Add nested fields if necessary
+    if (startTimeBegin !== undefined || startTimeEnd !== undefined) {
+      query.startTime = {};
+      if (startTimeBegin !== undefined) query.startTime.$gte = startTimeBegin;
+      if (startTimeEnd !== undefined) query.startTime.$lt = startTimeEnd;
+      if (Object.keys(query.startTime).length === 0) delete query.startTime;
+    }
+
+    if (deadlineBegin !== undefined || deadlineEnd !== undefined) {
+      query.deadline = {};
+      if (deadlineBegin !== undefined) query.deadline.$gte = deadlineBegin;
+      if (deadlineEnd !== undefined) query.deadline.$lt = deadlineEnd;
+      if (Object.keys(query.deadline).length === 0) delete query.deadline;
+    }
     return (await this.assessmentModel.find(query).exec()).map((assesment) => assesment.toObject());
   }
 

--- a/test/e2e/assessment.e2e.test.ts
+++ b/test/e2e/assessment.e2e.test.ts
@@ -85,14 +85,6 @@ describe('Course e2e', () => {
     await app.close();
   });
 
-  /**
-   * Casos a ver:
-   * - getAssessments (con buena y mala query)
-   * - getAssess
-   * - updateAssess (con buen y mal body)
-   * - deleteAssess
-   */
-
   test('GET /assessments should retreive all the existing assessments', async () => {
     const course = await createCourse();
     const assessment = await createAssessment(course.id, AssessmentType.Exam.toString());
@@ -115,8 +107,14 @@ describe('Course e2e', () => {
     await createAssessment(course.id, AssessmentType.Exam.toString());
 
     const expected = [];
-
-    const result = await request(app.getHttpServer()).get('/assessments?type=Task').send();
+    // Create ranges that does not include startDate nor deadline
+    const startTimeBegin = new Date(startDate.getTime() + 1).toISOString();
+    const startTimeEnd = new Date(startDate.getTime() + 2).toISOString();
+    const deadlineBegin = new Date(deadline.getTime() + 1).toISOString();
+    const deadlineEnd = new Date(deadline.getTime() + 2).toISOString();
+    // range in url never include the assessment registered
+    const url = `/assessments?startTimeBegin=${startTimeBegin}&startTimeEnd=${startTimeEnd}&deadlineBegin=${deadlineBegin}&deadlineEnd=${deadlineEnd}`;
+    const result = await request(app.getHttpServer()).get(url).send();
 
     expect(result.body).toHaveProperty('data');
     const data = result.body.data;


### PR DESCRIPTION
Add the properties `startTimeBegin`, `startTimeEnd`, `deadlineBegin` and `deadlineEnd` to _filter_ dto in endpoint `GET assessments` to get range of dates either for startTime and deadline